### PR TITLE
Sequence removal.

### DIFF
--- a/hydra-java-client/src/main/java/org/cardanofoundation/hydra/client/HydraClientOptions.java
+++ b/hydra-java-client/src/main/java/org/cardanofoundation/hydra/client/HydraClientOptions.java
@@ -11,9 +11,6 @@ public class HydraClientOptions {
     private final String serverURI;
 
     @Builder.Default
-    private int fromSeq = 0;
-
-    @Builder.Default
     private boolean history = false;
 
     /**


### PR DESCRIPTION
Since hydra supports lightweight mode (without history) we don't need sequence anymore. For clients that want to fully replay history they will just connect with history = yes.