### PR TITLE
feat: introduced test-containers support module

### DIFF
--- a/hydra-java-client/pom.xml
+++ b/hydra-java-client/pom.xml
@@ -48,6 +48,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.cardanofoundation</groupId>
+            <artifactId>hydra-java-test-containers-support</artifactId>
+            <version>0.0.7-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -86,7 +93,9 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest1.java
+++ b/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest1.java
@@ -1,17 +1,13 @@
-package org.cardanofoundation.hydra.client.client;
+package org.cardanofoundation.hydra.client;
 
 import com.google.common.base.Stopwatch;
 import lombok.extern.slf4j.Slf4j;
-import org.cardanofoundation.hydra.client.HydraClientOptions;
-import org.cardanofoundation.hydra.client.HydraQueryEventListener;
-import org.cardanofoundation.hydra.client.HydraWSClient;
-import org.cardanofoundation.hydra.client.SLF4JHydraLogger;
-import org.cardanofoundation.hydra.client.client.helpers.HydraDevNetwork;
 import org.cardanofoundation.hydra.core.model.HydraState;
 import org.cardanofoundation.hydra.core.model.UTXO;
 import org.cardanofoundation.hydra.core.model.query.response.GreetingsResponse;
 import org.cardanofoundation.hydra.core.model.query.response.Response;
 import org.cardanofoundation.hydra.core.store.InMemoryUTxOStore;
+import org.cardanofoundation.hydra.test.HydraDevNetwork;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest2.java
+++ b/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest2.java
@@ -1,15 +1,11 @@
-package org.cardanofoundation.hydra.client.client;
+package org.cardanofoundation.hydra.client;
 
 import com.google.common.base.Stopwatch;
 import lombok.extern.slf4j.Slf4j;
-import org.cardanofoundation.hydra.client.HydraClientOptions;
-import org.cardanofoundation.hydra.client.HydraQueryEventListener;
-import org.cardanofoundation.hydra.client.HydraWSClient;
-import org.cardanofoundation.hydra.client.SLF4JHydraLogger;
-import org.cardanofoundation.hydra.client.client.helpers.HydraDevNetwork;
 import org.cardanofoundation.hydra.core.model.HydraState;
 import org.cardanofoundation.hydra.core.model.query.response.Response;
 import org.cardanofoundation.hydra.core.store.InMemoryUTxOStore;
+import org.cardanofoundation.hydra.test.HydraDevNetwork;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -30,7 +26,7 @@ public class HydraWSClientIntegrationTest2 {
      * - connecting to the head
      * - alice sends init command (getting Hydra in the intializing state)
      * - bob decides to abort
-     * - head reaches aborted state
+     * - head reaches aborted final
      */
     @Test
     public void testHydraNetworkReachesAbortState() throws InterruptedException {

--- a/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest3.java
+++ b/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/HydraWSClientIntegrationTest3.java
@@ -1,4 +1,4 @@
-package org.cardanofoundation.hydra.client.client;
+package org.cardanofoundation.hydra.client;
 
 import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
@@ -9,16 +9,12 @@ import org.cardanofoundation.hydra.cardano.client.lib.HydraOperator;
 import org.cardanofoundation.hydra.cardano.client.lib.JacksonClasspathProtocolParametersSupplier;
 import org.cardanofoundation.hydra.cardano.client.lib.JacksonClasspathSecretKeySupplierHydra;
 import org.cardanofoundation.hydra.cardano.client.lib.SnapshotUTxOSupplier;
-import org.cardanofoundation.hydra.client.HydraClientOptions;
-import org.cardanofoundation.hydra.client.HydraQueryEventListener;
-import org.cardanofoundation.hydra.client.HydraWSClient;
-import org.cardanofoundation.hydra.client.SLF4JHydraLogger;
-import org.cardanofoundation.hydra.client.client.helpers.HydraDevNetwork;
-import org.cardanofoundation.hydra.client.client.helpers.HydraTransactionGenerator;
+import org.cardanofoundation.hydra.client.helpers.HydraTransactionGenerator;
 import org.cardanofoundation.hydra.core.model.HydraState;
 import org.cardanofoundation.hydra.core.model.UTXO;
 import org.cardanofoundation.hydra.core.model.query.response.*;
 import org.cardanofoundation.hydra.core.store.InMemoryUTxOStore;
+import org.cardanofoundation.hydra.test.HydraDevNetwork;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/helpers/HydraTransactionGenerator.java
+++ b/hydra-java-client/src/test/java/org/cardanofoundation/hydra/client/helpers/HydraTransactionGenerator.java
@@ -1,4 +1,4 @@
-package org.cardanofoundation.hydra.client.client.helpers;
+package org.cardanofoundation.hydra.client.helpers;
 
 import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
 import com.bloxbean.cardano.client.api.UtxoSupplier;

--- a/hydra-java-test-containers-support/pom.xml
+++ b/hydra-java-test-containers-support/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cardanofoundation</groupId>
+        <artifactId>hydra-java</artifactId>
+        <version>0.0.7-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hydra-java-test-containers-support</artifactId>
+
+    <properties>
+        <java.version>11</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/hydra-java-test-containers-support/src/main/java/org/cardanofoundation/hydra/test/HydraDevNetwork.java
+++ b/hydra-java-test-containers-support/src/main/java/org/cardanofoundation/hydra/test/HydraDevNetwork.java
@@ -1,4 +1,4 @@
-package org.cardanofoundation.hydra.client.client.helpers;
+package org.cardanofoundation.hydra.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Files;

--- a/pom.xml
+++ b/pom.xml
@@ -105,35 +105,30 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.core.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit-jupiter-engine.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitability.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -308,6 +303,7 @@
         <module>hydra-java-core</module>
         <module>hydra-java-client</module>
         <module>hydra-java-cardano-client-lib-adapter</module>
+        <module>hydra-java-test-containers-support</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Moving of HydraDevNet helper class from test folder to separate module. This allows one to use the helper in the developer's integration tests (upstream) without relying copying and pasting the helper class.